### PR TITLE
quick hack for multiple grid height scope scaling

### DIFF
--- a/src/FullScope.cpp
+++ b/src/FullScope.cpp
@@ -253,7 +253,8 @@ struct FullScopeDisplay : TransparentWidget {
 
 struct FullScopeWidget : ModuleWidget {
 	Panel *panel;
-	Widget *rightHandle;
+	JWModuleResizeHandle *leftHandle;
+	JWModuleResizeHandle *rightHandle;
 	TransparentWidget *display;
 	FullScopeWidget(FullScope *module);
 	void step() override;
@@ -272,10 +273,9 @@ FullScopeWidget::FullScopeWidget(FullScope *module) : ModuleWidget(module) {
 		addChild(panel);
 	}
 
-	JWModuleResizeHandle *leftHandle = new JWModuleResizeHandle(box.size.x);
-	JWModuleResizeHandle *rightHandle = new JWModuleResizeHandle(box.size.x);
+	leftHandle = new JWModuleResizeHandle(box.size.x);
+	rightHandle = new JWModuleResizeHandle(box.size.x);
 	rightHandle->right = true;
-	this->rightHandle = rightHandle;
 	addChild(leftHandle);
 	addChild(rightHandle);
 
@@ -283,7 +283,7 @@ FullScopeWidget::FullScopeWidget(FullScope *module) : ModuleWidget(module) {
 		FullScopeDisplay *display = new FullScopeDisplay();
 		display->module = module;
 		display->box.pos = Vec(0, 0);
-		display->box.size = Vec(box.size.x, RACK_GRID_HEIGHT);
+		display->box.size = Vec(box.size.x, box.size.y);
 		addChild(display);
 		this->display = display;
 	}
@@ -308,8 +308,10 @@ FullScopeWidget::FullScopeWidget(FullScope *module) : ModuleWidget(module) {
 
 void FullScopeWidget::step() {
 	panel->box.size = box.size;
-	display->box.size = Vec(box.size.x, RACK_GRID_HEIGHT);
+	display->box.size = Vec(box.size.x, box.size.y);
 	rightHandle->box.pos.x = box.size.x - rightHandle->box.size.x;
+	rightHandle->box.pos.y = box.size.y - rightHandle->box.size.y;
+	leftHandle->box.pos.y = box.size.y - leftHandle->box.size.y;
 	ModuleWidget::step();
 }
 

--- a/src/JWResizableHandle.hpp
+++ b/src/JWResizableHandle.hpp
@@ -8,6 +8,7 @@ struct JWModuleResizeHandle : Widget {
 	float minWidth;
 	bool right = false;
 	float dragX;
+	float dragY;
 	Rect originalBox;
 
 	JWModuleResizeHandle(float _minWidth) {
@@ -24,6 +25,7 @@ struct JWModuleResizeHandle : Widget {
 
 	void onDragStart(EventDragStart &e) override {
 		dragX = gRackWidget->lastMousePos.x;
+		dragY = gRackWidget->lastMousePos.y;
 		ModuleWidget *m = getAncestorOfType<ModuleWidget>();
 		originalBox = m->box;
 	}
@@ -33,8 +35,12 @@ struct JWModuleResizeHandle : Widget {
 
 		float newDragX = gRackWidget->lastMousePos.x;
 		float deltaX = newDragX - dragX;
+		float newDragY = gRackWidget->lastMousePos.y;
+		float deltaY = newDragY - dragY;
 
 		Rect newBox = originalBox;
+		
+		// resize width
 		if (right) {
 			newBox.size.x += deltaX;
 			newBox.size.x = fmaxf(newBox.size.x, minWidth);
@@ -46,6 +52,12 @@ struct JWModuleResizeHandle : Widget {
 			newBox.size.x = roundf(newBox.size.x / RACK_GRID_WIDTH) * RACK_GRID_WIDTH;
 			newBox.pos.x = originalBox.pos.x + originalBox.size.x - newBox.size.x;
 		}
+
+		// resize height
+		newBox.size.y += deltaY;
+		newBox.size.y = fmaxf(newBox.size.y, RACK_GRID_HEIGHT);
+		newBox.size.y = roundf(newBox.size.y / RACK_GRID_HEIGHT) * RACK_GRID_HEIGHT;
+
 		gRackWidget->requestModuleBox(m, newBox);
 	}
 };


### PR DESCRIPTION
A simple fix for the knobs and connectors would be to place them at the bottom side instead at the bottom side, otherwise they would need to move, too, like the handles. Vertical size needs to be saved and restored from json as well.