### PR TITLE
Fix memory leaks

### DIFF
--- a/src/NoteSeqFu.cpp
+++ b/src/NoteSeqFu.cpp
@@ -218,6 +218,7 @@ struct NoteSeqFu : Module,QuantizeUtils {
 		delete [] colNotesCache;
 		delete [] colNotesCache2;
 		delete [] playHeads;
+		delete [] hitEnd;
 	}
 
 	void onRandomize() override {

--- a/src/Trigs.cpp
+++ b/src/Trigs.cpp
@@ -446,6 +446,10 @@ struct TrigsDisplay : LightWidget {
 		colors[3] = nvgRGB(25, 150, 252);//blue
 	}
 
+	~TrigsDisplay() {
+		delete [] colors;
+	}
+
 	void onButton(const event::Button &e) override {
 		if (e.action == GLFW_PRESS && e.button == GLFW_MOUSE_BUTTON_LEFT) {
 			e.consume(this);


### PR DESCRIPTION
As title says.
These were auto-detected by valgrind.

```
==890428== 64 bytes in 1 blocks are definitely lost in loss record 2,255 of 3,615
==890428==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0x19EC3EB: TrigsDisplay::TrigsDisplay() (Trigs.cpp:442)
==890428==    by 0x19E957E: TrigsWidget::TrigsWidget(Trigs*) (Trigs.cpp:614)
==890428==    by 0x19ED861: rack::CardinalPluginModel<Trigs, TrigsWidget>::createModuleWidget(rack::engine::Module*) (helpers.hpp:70)
==890428==    by 0x6B3ACD: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:491)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428== 

==890428== 4 bytes in 1 blocks are definitely lost in loss record 6 of 3,615
==890428==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0x19BD96D: NoteSeqFu::NoteSeqFu() (NoteSeqFu.cpp:149)
==890428==    by 0x19C583D: rack::CardinalPluginModel<NoteSeqFu, NoteSeqFuWidget>::createModule() (helpers.hpp:52)
==890428==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428== 
```